### PR TITLE
GenericValue: add copy constructor and CopyFrom

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -70,6 +70,16 @@ public:
 		memset(&data_, 0, sizeof(data_));
 	}
 
+	//! Explicit copy constructor (with allocator)
+	/*! Creates a copy of a Value by using the given Allocator
+		\tparam SourceAllocator allocator of \c rhs
+		\param rhs Value to copy from (read-only)
+		\param allocator Allocator to use for copying
+		\see CopyFrom()
+	*/
+	template< typename SourceAllocator >
+	GenericValue(const GenericValue<Encoding,SourceAllocator>& rhs, Allocator & allocator);
+
 	//! Constructor for boolean value.
 	GenericValue(bool b) : flags_(b ? kTrueFlag : kFalseFlag) {}
 
@@ -185,6 +195,21 @@ public:
 		new (this) GenericValue(value);
 		return *this;
 	}
+
+	//! Deep-copy assignment from Value
+	/*! Assigns a \b copy of the Value to the current Value object
+		\tparam SourceAllocator Allocator type of \c rhs
+		\param rhs Value to copy from (read-only)
+		\param allocator Allocator to use for copying
+	 */
+	template <typename SourceAllocator>
+	GenericValue& CopyFrom(const GenericValue<Encoding,SourceAllocator>& rhs, Allocator& allocator) {
+		RAPIDJSON_ASSERT((void*)this != (void*)&rhs);
+		this->~GenericValue();
+		new (this) GenericValue(rhs,allocator);
+		return *this;
+	}
+
 	//@}
 
 	//!@name Type
@@ -781,8 +806,10 @@ public:
 	//! Get the capacity of stack in bytes.
 	size_t GetStackCapacity() const { return stack_.GetCapacity(); }
 
-//private:
-	//friend class GenericReader<Encoding>;	// for Reader to call the following private handler functions
+private:
+	// callers of the following private Handler functions
+	template <typename,typename,typename> friend class GenericReader; // for parsing
+	friend class GenericValue<Encoding,Allocator>; // for deep copying
 
 	// Implementation of Handler
 	void Null()	{ new (stack_.template Push<ValueType>()) ValueType(); }
@@ -833,6 +860,17 @@ private:
 };
 
 typedef GenericDocument<UTF8<> > Document;
+
+// defined here due to the dependency on GenericDocument
+template <typename Encoding, typename Allocator>
+template <typename SourceAllocator>
+inline
+GenericValue<Encoding,Allocator>::GenericValue(const GenericValue<Encoding,SourceAllocator>& rhs, Allocator& allocator)
+{
+	GenericDocument<Encoding,Allocator> d(&allocator);
+	rhs.Accept(d);
+	RawAssign(*d.stack_.template Pop<GenericValue>(1));
+}
 
 } // namespace rapidjson
 

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -527,7 +527,7 @@ int z = a[0u].GetInt();				// This works too.
 		case kObjectType:
 			handler.StartObject();
 			for (Member* m = data_.o.members; m != data_.o.members + data_.o.size; ++m) {
-				handler.String(m->name.data_.s.str, m->name.data_.s.length, false);
+				handler.String(m->name.data_.s.str, m->name.data_.s.length, m->name.flags_ & kCopyFlag);
 				m->value.Accept(handler);
 			}
 			handler.EndObject(data_.o.size);
@@ -541,7 +541,7 @@ int z = a[0u].GetInt();				// This works too.
 			break;
 
 		case kStringType:
-			handler.String(data_.s.str, data_.s.length, false);
+			handler.String(data_.s.str, data_.s.length, flags_ & kCopyFlag);
 			break;
 
 		case kNumberType:

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -25,6 +25,36 @@ TEST(Value, assignment_operator) {
 	EXPECT_EQ(1234, y.GetInt());
 }
 
+TEST(Value, CopyFrom)
+{
+	// use CrtAllocator to explicitly malloc/free any memory
+	// comment this line to use the default Allocator instead
+	typedef GenericValue<UTF8<>,CrtAllocator> Value;
+
+	Value::AllocatorType a;
+	Value v1(1234);
+	Value v2(v1,a); // deep copy constructor
+	EXPECT_TRUE(v1.GetType() == v2.GetType());
+	EXPECT_EQ(v1.GetInt(), v2.GetInt());
+
+	v1.SetString("foo");
+	v2.CopyFrom(v1,a);
+	EXPECT_TRUE(v1.GetType() == v2.GetType());
+	EXPECT_STREQ(v1.GetString(), v2.GetString());
+	EXPECT_EQ(v1.GetString(), v2.GetString()); // string NOT copied
+
+	v1.SetArray().PushBack(1234,a);
+	v2.CopyFrom(v1,a);
+	EXPECT_TRUE(v2.IsArray());
+	EXPECT_EQ(v1.Size(), v2.Size());
+
+	v1.PushBack(Value().SetString("foo",a),a); // push string copy
+	EXPECT_TRUE(v1.Size() != v2.Size());
+	v2.CopyFrom(v1,a);
+	EXPECT_TRUE(v1.Size() == v2.Size());
+	EXPECT_STREQ(v1[1].GetString(), v2[1].GetString());
+	EXPECT_NE(v1[1].GetString(), v2[1].GetString()); // string got copied
+}
 
 TEST(Value, Null) {
 	// Default constructor


### PR DESCRIPTION
To allow deep copying from an existing `GenericValue`, an explicit "copy constructor" (with required Allocator param) and a `CopyFrom` assignment function are added.

```
  Document d; Document::AllocatorType& a = d.GetAllocator();
  Value v1("foo");
  // Value v2(v1); // not allowed

  Value v2(v1,a);                             // make a copy
  RAPIDJSON_ASSERT(v1.IsString());            // v1 untouched
  d.SetArray().PushBack(v1,a).PushBack(v2,a);
  RAPIDJSON_ASSERT(v1.Empty() && v2.Empty());

  v2.CopyFrom(d,a);                           // copy whole document
  RAPIDJSON_ASSERT(d.IsArray() && d.Size());  // d untouched
  v1.SetObject().AddMember( "array", v2, a );
  d.PushBack(v1,a);
```

The strings in the source value are copied, if and only if they have been allocated as a copy during their construction (determined by `kCopyFlag`).  This is needed to avoid double `free()`s or problems with differing lifetimes of the allocated string storage.

Additionally, the `Handler` implementation in `GenericDocument` is made private again, restricting access to `GenericReader` and `GenericValue`.
